### PR TITLE
Use absolute path for entrypoint

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -11,4 +11,4 @@ RUN apk --update add curl tar && \
 
 EXPOSE 1313
 
-ENTRYPOINT ["./bin/hugo"]
+ENTRYPOINT ["/bin/hugo"]


### PR DESCRIPTION
It allows to use this container with `WORKDIR`.
